### PR TITLE
legal2md Windows Command Prompt Partial Fix (I Think)

### DIFF
--- a/lib/legal_markdown.rb
+++ b/lib/legal_markdown.rb
@@ -86,3 +86,6 @@ module LegalMarkdown
   end
 end
 
+
+
+LegalMarkdown::parse(ARGV)

--- a/lib/legal_markdown/legal_to_markdown/leaders.rb
+++ b/lib/legal_markdown/legal_to_markdown/leaders.rb
@@ -81,7 +81,7 @@ module LegalToMarkdown
         no_indent_array = @headers["no-indent"].split(", ")
         no_indent_array.include?("l." || "l1.") ? @offset = no_indent_array.size : @offset = no_indent_array.size + 1
       else
-        @offset = 1
+         @offset = 1
       end
       @headers.delete("no-indent")
     end

--- a/lib/legal_markdown/roman-numerals.rb
+++ b/lib/legal_markdown/roman-numerals.rb
@@ -1,0 +1,77 @@
+# Extracted from Roman Numerals gem
+
+# Copyright (c) 2011 Andrew Vos
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+module RomanNumerals
+  @base_digits = {
+    1    => 'I',
+    4    => 'IV',
+    5    => 'V',
+    9    => 'IX',
+    10   => 'X',
+    40   => 'XL',
+    50   => 'L',
+    90   => 'XC',
+    100  => 'C',
+    400  => 'CD',
+    500  => 'D',
+    900  => 'CM',
+    1000 => 'M'
+  }
+
+  def self.to_roman_upper(value)
+    value = value.to_i
+    result = ''
+    @base_digits.keys.reverse.each do |decimal|
+      while value >= decimal
+        value -= decimal
+        result += @base_digits[decimal]
+      end
+    end
+    result
+  end
+
+  def self.to_roman_lower(value)
+    value = value.to_i
+    result = ''
+    @base_digits.keys.reverse.each do |decimal|
+      while value >= decimal
+        value -= decimal
+        result += @base_digits[decimal]
+      end
+    end
+    result.downcase
+  end
+
+  def self.to_decimal_string(value)
+    value.upcase!
+    result = 0
+    @base_digits.values.reverse.each do |roman|
+      while value.start_with? roman
+        value = value.slice(roman.length, value.length)
+        result += @base_digits.key roman
+      end
+    end
+    result.to_s
+  end
+end


### PR DESCRIPTION
The text from my commit:

As Legal-Markdown-Sublime was processing files successfully, I cross-checked that repository's version of legal_markdown.rb against the version that was not working for me in the Legal-Markdown repository. There were differences, so I conformed the Legal-Markdown version to the Legal-Markdown-Sublime version.

That was progress, but not the end of the story. At the command prompt, `legal2md` was still throwing `NoMethodError` exceptions on the `@headers` in `leaders.rb`. This appears to be because my input file
lacked a complete set of YAML front-matter. Once I included at least placeholders for the three `Properties` headers (`no-indent`, `no-reset`, and `level-style`) I was successful in running `legal2md [input file] [output file]` and `legal2md -b [input file] [output file]` from the Windows 7 Command Prompt without it returning the previous error, which was: `Sorry, I could not read the file ["--headers", "test.lmd"]: no implicit conversion of Array into String.`

Commit `b2e30ef` adds a file or two from the Sublime repo, but it is not clear to me that those changes had any effect on the above.

I was running Ruby version 2.0.0p247.
